### PR TITLE
Fixes font family bug on IOS

### DIFF
--- a/src/MaterialDialog.js
+++ b/src/MaterialDialog.js
@@ -3,6 +3,7 @@ import {
   StyleSheet,
   Modal,
   Text,
+  Platform,
   TouchableHighlight,
   TouchableWithoutFeedback,
   View,
@@ -119,7 +120,14 @@ const styles = StyleSheet.create({
   },
   titleText: {
     fontSize: 20,
-    fontFamily: 'sans-serif-medium',
+    ...Platform.select({
+      android: {
+        fontFamily: 'sans-serif-medium',
+      },
+      ios:  {
+        fontWeight: '600'
+      }
+    })
   },
   contentContainer: {
     flex: -1,
@@ -157,7 +165,14 @@ const styles = StyleSheet.create({
   },
   actionText: {
     fontSize: 14,
-    fontFamily: 'sans-serif-medium',
+    ...Platform.select({
+      android: {
+        fontFamily: 'sans-serif-medium',
+      },
+      ios:  {
+        fontWeight: '600'
+      }
+    })
   },
 });
 

--- a/src/MultiPickerMaterialDialog.js
+++ b/src/MultiPickerMaterialDialog.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View, ListView } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View, ListView, Platform } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import MaterialDialog from './MaterialDialog';
 
@@ -113,7 +113,7 @@ const styles = StyleSheet.create({
   },
   rowText:
   {
-    fontFamily: 'sans-serif',
+    fontFamily: Platform.OS === 'android' ? 'sans-serif' : 'System',
     color: colors.androidPrimaryTextColor,
     fontSize: 16,
   },

--- a/src/SinglePickerMaterialDialog.js
+++ b/src/SinglePickerMaterialDialog.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View, ListView } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View, ListView, Platform } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import MaterialDialog from './MaterialDialog';
 
@@ -126,7 +126,14 @@ const styles = StyleSheet.create({
   },
   rowText:
   {
-    fontFamily: 'sans-serif',
+    ...Platform.select({
+      android: {
+        fontFamily: 'sans-serif-medium',
+      },
+      ios:  {
+        fontWeight: '600'
+      }
+    }),
     color: colors.androidPrimaryTextColor,
     fontSize: 16,
   },


### PR DESCRIPTION
Fixes #1 for all 3 modals

IOS' equivalent to `fontFamily 'sans-serif-medium'` is `fontWeight: '600'`
IOS' equivalent to `fontFamily: 'sans-serif'` is `fontFamily: 'System'`