### PR TITLE
Typings - Fixes typescript errors for children prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -68,7 +68,7 @@ interface MaterialDialogStatic extends Dialog {
     /**
      * Content of the dialog
      */
-    children: JSX.Element
+    children?: JSX.Element
 }
 
 


### PR DESCRIPTION
Typescript doesn't have a way to reinforce nested components. 
Example in our case the `children` prop. 

This pr makes the children prop optional for typescript however the user will still get the warning from React.propTypes.isRequired.

Reference https://github.com/Microsoft/TypeScript/issues/6471