### PR TITLE
Title prop on Multipicker and Singlepicker should be optional

### DIFF
--- a/src/MultiPickerMaterialDialog.js
+++ b/src/MultiPickerMaterialDialog.js
@@ -123,7 +123,7 @@ MultiPickerMaterialDialog.propTypes = {
   visible: PropTypes.bool.isRequired,
   items: PropTypes.arrayOf(PropTypes.object).isRequired,
   selectedItems: PropTypes.arrayOf(PropTypes.object),
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   titleColor: PropTypes.string,
   colorAccent: PropTypes.string,
   onCancel: PropTypes.func.isRequired,

--- a/src/SinglePickerMaterialDialog.js
+++ b/src/SinglePickerMaterialDialog.js
@@ -143,7 +143,7 @@ SinglePickerMaterialDialog.propTypes = {
   visible: PropTypes.bool.isRequired,
   items: PropTypes.arrayOf(PropTypes.object).isRequired,
   selectedItem: PropTypes.object,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   titleColor: PropTypes.string,
   colorAccent: PropTypes.string,
   onCancel: PropTypes.func.isRequired,


### PR DESCRIPTION
Having these pickers without title shouldn't show a warning. This is a normal use case.

![screen shot 2017-05-25 at 2 33 18 pm](https://cloud.githubusercontent.com/assets/5962998/26465057/d47c00fa-4157-11e7-8815-93f2bcdd8a24.png)
