### PR TITLE
Replace React.PropTypes with PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "modal"
   ],
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react-native-vector-icons": "^4.0.0"
   },
   "devDependencies": {

--- a/src/MaterialDialog.js
+++ b/src/MaterialDialog.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   StyleSheet,
   Modal,

--- a/src/MultiPickerMaterialDialog.js
+++ b/src/MultiPickerMaterialDialog.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { StyleSheet, Text, TouchableOpacity, View, ListView, Platform } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import MaterialDialog from './MaterialDialog';

--- a/src/SinglePickerMaterialDialog.js
+++ b/src/SinglePickerMaterialDialog.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { StyleSheet, Text, TouchableOpacity, View, ListView, Platform } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import MaterialDialog from './MaterialDialog';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1020,14 +1020,14 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.8:
+prop-types@^15.5.10, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
-react-native-vector-icons@^4.0.0:
+react-native-vector-icons@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-4.2.0.tgz#0594b68debdd758dce4c565bf02e2d64d7004d82"
   dependencies:


### PR DESCRIPTION
PropTypes from the react package was deprecated and moved to `prop-types` in reactv15.5 so it shows errors in react native projects.

The react-native-vector-icons library already made this fix, however you were depending on an older version of the library.

This PR makes the fix for PropTypes, and also updates the react-native-vector-icons version