### PR TITLE
Update react-native-vector-icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "modal"
   ],
   "dependencies": {
-    "react-native-vector-icons": "^4.0.0"
+    "react-native-vector-icons": "^4.2.0"
   },
   "devDependencies": {
     "eslint": "^3.16.1",


### PR DESCRIPTION
Reference #17 

"The react-native-vector-icons library already made the prop-types fix, however you were depending on an older version of the library."