### PR TITLE
[MaterialDialog] Support landscape orientation

### DIFF
--- a/src/MaterialDialog.js
+++ b/src/MaterialDialog.js
@@ -49,6 +49,7 @@ const MaterialDialog = ({
     hardwareAccelerated
     visible={visible}
     onRequestClose={onCancel}
+    supportedOrientations={['portrait', 'landscape']}
   >
     <TouchableWithoutFeedback onPress={onCancel}>
       <View style={styles.backgroundOverlay}>


### PR DESCRIPTION
Hey, @hectahertz! 👋

Currently, `MaterialDialog` does not work in `landscape` orientation on iOS.
When a `MaterialDialog` is opened in `landscape` mode, the `Modal` switches the orientation back to `portrait` and then the dialog is opened.

It works as expected in both orientations on Android.

This PR fixes the issue on iOS, and `MaterialDialog` now works in both orientations on both iOS and Android.

See:

- [https://facebook.github.io/react-native/docs/modal.html#supportedorientations](https://facebook.github.io/react-native/docs/modal.html#supportedorientations)
- facebook/react-native#11036

Thanks! 😃