### PR TITLE
Fix Typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -137,6 +137,6 @@ interface MultiPickerMaterialDialogStatic extends Dialog {
     selectedItems: PickerItem[]
 }
 
-export class MaterialDialog extends React.Component<MaterialDialogStatic, null> {} 
-export class SinglePickerMaterialDialog extends React.Component<SinglePickerMaterialDialogStatic, null> {}
-export class MultiPickerMaterialDialog extends React.Component<MultiPickerMaterialDialogStatic, null> {}
+export class MaterialDialog extends React.Component<MaterialDialogStatic> {} 
+export class SinglePickerMaterialDialog extends React.Component<SinglePickerMaterialDialogStatic> {}
+export class MultiPickerMaterialDialog extends React.Component<MultiPickerMaterialDialogStatic> {}


### PR DESCRIPTION
Current typing is not compatible with `@types/react` 15.6 and `typescript` 2.6.2. 

Error message: 
```
[ts]
JSX element type 'MaterialDialog' is not a constructor function for JSX elements.
  Types of property 'setState' are incompatible.
    Type '{ <K extends never>(f: (prevState: null, props: MaterialDialogStatic) => Pick<null, K>, callback?...' is not assignable to type '{ <K extends never>(f: (prevState: {}, props: any) => Pick<{}, K>, callback?: (() => any) | undef...'.
      Types of parameters 'f' and 'f' are incompatible.
        Types of parameters 'prevState' and 'prevState' are incompatible.
          Type 'null' is not assignable to type '{}'.
```

The PR fixed this issue.