### PR TITLE
Added onShow and onDismiss to MaterialDialog and forwarded all unused props.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -91,6 +91,9 @@ interface Dialog {
      * @param selected
      */
     onCancel?(selected: SelectedItem): void
+
+    onShow?(): void
+    onDismiss?(): void
 }
 
 interface MaterialDialogStatic extends Dialog {

--- a/src/MaterialDialog.js
+++ b/src/MaterialDialog.js
@@ -44,8 +44,12 @@ const MaterialDialog = ({
   okLabel,
   cancelLabel,
   children,
+  onShow,
+  onDismiss,
+  ...other
 }) => (
   <Modal
+    {...other}
     animationType={'fade'}
     transparent
     hardwareAccelerated
@@ -198,6 +202,8 @@ MaterialDialog.propTypes = {
   colorAccent: PropTypes.string,
   scrolled: PropTypes.bool,
   addPadding: PropTypes.bool,
+  onShow: PropTypes.func,
+  onDismiss: PropTypes.func,
 };
 
 MaterialDialog.defaultProps = {
@@ -211,6 +217,8 @@ MaterialDialog.defaultProps = {
   addPadding: true,
   onOk: undefined,
   onCancel: undefined,
+  onShow: undefined,
+  onDismiss: undefined,
 };
 
 ActionButton.propTypes = {


### PR DESCRIPTION
I needed to access the onShow and onDismiss props of the Modal so I forwarded those. I also forwarded all other props in case someone else needs something.

I added the onShow and onDismiss separately for type checking. Tell me if I should remove that.